### PR TITLE
 Fix [UI] - documentation menu hard to close on mobile  (#1098)

### DIFF
--- a/ui/src/components/Dashboard/index.jsx
+++ b/ui/src/components/Dashboard/index.jsx
@@ -84,6 +84,9 @@ import SkipNavigation from '../SkipNavigation';
     },
     docsDrawerPaper: {
       width: theme.docsDrawerWidth,
+      [theme.breakpoints.down('xs')]: {
+        width: theme.spacing.unit * 30,
+      },
     },
     helpDrawerPaper: {
       width: '40vw',


### PR DESCRIPTION
* Fix [UI] - documentation menu hard to close-mobile

*  Fix [UI]- documentation menu hard to close-mobile

* Small fix #1

<!-- If this is related to a Bugzilla bug, please begin your title with [Bug XXXXX]
     and update this link.

     Is this change user-visible?  If so, please include a file in changelog/ describing it.
     See https://github.com/taskcluster/taskcluster/blob/master/dev-docs/best-practices/changelog.md
-->

Bugzilla Bug: [XXXXX](https://bugzilla.mozilla.org/show_bug.cgi?id=XXXXX)
